### PR TITLE
feat: scaffold NestJS backend with Postgres and frontend fetch

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+/dist
+

--- a/backend/nest-cli.json
+++ b/backend/nest-cli.json
@@ -1,0 +1,4 @@
+{
+  "collection": "@nestjs/schematics",
+  "sourceRoot": "src"
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "IT Admin Panel backend",
+  "scripts": {
+    "build": "nest build",
+    "start": "nest start",
+    "start:dev": "nest start --watch",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/typeorm": "^10.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.8.0",
+    "typeorm": "^0.3.17",
+    "pg": "^8.11.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^10.0.0",
+    "@nestjs/schematics": "^10.0.0",
+    "@nestjs/testing": "^10.0.0",
+    "@types/node": "^20.0.0",
+    "jest": "^29.0.0",
+    "ts-jest": "^29.0.0",
+    "ts-loader": "^9.4.2",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.0"
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DepartmentsModule } from './departments/departments.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || '5432', 10),
+      username: process.env.DB_USER || 'postgres',
+      password: process.env.DB_PASSWORD || 'postgres',
+      database: process.env.DB_NAME || 'it_inventory',
+      autoLoadEntities: true,
+      synchronize: true,
+    }),
+    DepartmentsModule,
+  ],
+})
+export class AppModule {}

--- a/backend/src/departments/department.entity.ts
+++ b/backend/src/departments/department.entity.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity()
+export class Department {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+}

--- a/backend/src/departments/departments.controller.ts
+++ b/backend/src/departments/departments.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+import { DepartmentsService } from './departments.service';
+import { Department } from './department.entity';
+
+@Controller('departments')
+export class DepartmentsController {
+  constructor(private readonly departmentsService: DepartmentsService) {}
+
+  @Get()
+  findAll(): Promise<Department[]> {
+    return this.departmentsService.findAll();
+  }
+}

--- a/backend/src/departments/departments.module.ts
+++ b/backend/src/departments/departments.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DepartmentsService } from './departments.service';
+import { DepartmentsController } from './departments.controller';
+import { Department } from './department.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Department])],
+  providers: [DepartmentsService],
+  controllers: [DepartmentsController],
+})
+export class DepartmentsModule {}

--- a/backend/src/departments/departments.service.ts
+++ b/backend/src/departments/departments.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Department } from './department.entity';
+
+@Injectable()
+export class DepartmentsService {
+  constructor(
+    @InjectRepository(Department)
+    private departmentsRepo: Repository<Department>,
+  ) {}
+
+  findAll(): Promise<Department[]> {
+    return this.departmentsRepo.find();
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3001);
+}
+bootstrap();

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test", "**/*spec.ts"]
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2017",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true
+  }
+}

--- a/it-admin-panel/app/departments/page.tsx
+++ b/it-admin-panel/app/departments/page.tsx
@@ -1,0 +1,16 @@
+import { getDepartments } from '@/lib/api';
+
+export default async function DepartmentsPage() {
+  const departments = await getDepartments();
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Departments</h1>
+      <ul>
+        {departments.map((dept: { id: number; name: string }) => (
+          <li key={dept.id}>{dept.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/it-admin-panel/lib/api.ts
+++ b/it-admin-panel/lib/api.ts
@@ -1,0 +1,9 @@
+export const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
+
+export async function getDepartments() {
+  const res = await fetch(`${API_URL}/departments`, { cache: 'no-store' });
+  if (!res.ok) {
+    throw new Error('Failed to fetch departments');
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- scaffold NestJS backend with TypeORM/Postgres and departments module
- add Next.js client page and API helper to fetch departments

## Testing
- `npm test` (backend) *(fails: jest not found)*
- `npm run build` (backend) *(fails: nest not found)*
- `npm run build` (frontend)
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5f29baff4832ea92ddb86c8878c1f