### PR TITLE
feat(ui-sidebar): localize branding text

### DIFF
--- a/it-admin-panel/components/layout/dashboard-sidebar.tsx
+++ b/it-admin-panel/components/layout/dashboard-sidebar.tsx
@@ -48,8 +48,8 @@ export function DashboardSidebar() {
             <Monitor className="h-4 w-4" />
           </div>
           <div className="flex flex-col">
-            <span className="text-sm font-semibold">IT Admin Panel</span>
-            <span className="text-xs text-muted-foreground">Management System</span>
+            <span className="text-sm font-semibold">{t("app.name")}</span>
+            <span className="text-xs text-muted-foreground">{t("app.tagline")}</span>
           </div>
         </div>
       </SidebarHeader>

--- a/it-admin-panel/lib/i18n.tsx
+++ b/it-admin-panel/lib/i18n.tsx
@@ -7,6 +7,10 @@ type Dict = Record<string, string>
 
 const dictionaries: Record<Lang, Dict> = {
   en: {
+    // App
+    "app.name": "IT Admin Panel",
+    "app.tagline": "Management System",
+
     // Common
     "common.change_language": "Change language",
     "common.add": "Add",
@@ -85,6 +89,10 @@ const dictionaries: Record<Lang, Dict> = {
     "sidebar.logout": "Logout",
   },
   tr: {
+    // App
+    "app.name": "BT Yönetim Paneli",
+    "app.tagline": "Yönetim Sistemi",
+
     "common.change_language": "Dili değiştir",
     "common.add": "Ekle",
     "common.edit": "Düzenle",
@@ -154,6 +162,10 @@ const dictionaries: Record<Lang, Dict> = {
     "sidebar.logout": "Çıkış",
   },
   tk: {
+    // App
+    "app.name": "IT Dolandyryş Paneli",
+    "app.tagline": "Dolandyryş Ulgamy",
+
     "common.change_language": "Dili üýtget",
     "common.add": "Goş",
     "common.edit": "Redaktirle",
@@ -223,6 +235,10 @@ const dictionaries: Record<Lang, Dict> = {
     "sidebar.logout": "Ulgamdan çyk",
   },
   ru: {
+    // App
+    "app.name": "Панель IT администратора",
+    "app.tagline": "Система управления",
+
     "common.change_language": "Сменить язык",
     "common.add": "Добавить",
     "common.edit": "Изменить",


### PR DESCRIPTION
## Summary
- add app name/tagline translations for all languages
- use i18n strings for sidebar branding

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b758424f28832e840cc35708f0845e