### PR TITLE
feat(mobile): add basic navigation and device screens

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,18 +1,21 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { StyleSheet } from 'react-native';
+import HomeScreen from './screens/HomeScreen.js';
+import DeviceListScreen from './screens/DeviceListScreen.js';
+
+const Stack = createNativeStackNavigator();
 
 export default function App() {
   return (
-    <View style={styles.container}>
-      <Text>IT Inventory Management</Text>
-    </View>
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Devices" component={DeviceListScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});
+const styles = StyleSheet.create({});

--- a/mobile/components/DeviceCard.js
+++ b/mobile/components/DeviceCard.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function DeviceCard({ device }) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.name}>{device.name}</Text>
+      <Text style={styles.type}>{device.type}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    padding: 16,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+    marginBottom: 12,
+  },
+  name: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  type: {
+    color: '#666',
+  },
+});

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -7,13 +7,17 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "lint": "eslint App.js"
+    "lint": "eslint ."
   },
   "dependencies": {
+    "@react-navigation/native": "^6.1.9",
+    "@react-navigation/native-stack": "^6.9.17",
     "expo": "^50.0.0",
     "expo-status-bar": "~1.11.1",
     "react": "18.2.0",
-    "react-native": "0.73.0"
+    "react-native": "0.73.0",
+    "react-native-safe-area-context": "^4.5.0",
+    "react-native-screens": "^3.29.0"
   },
   "private": true
 }

--- a/mobile/screens/DeviceListScreen.js
+++ b/mobile/screens/DeviceListScreen.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { FlatList, StyleSheet, View } from 'react-native';
+import DeviceCard from '../components/DeviceCard.js';
+
+const mockDevices = [
+  { id: '1', name: 'Laptop A', type: 'Laptop' },
+  { id: '2', name: 'Monitor B', type: 'Monitor' },
+  { id: '3', name: 'Printer C', type: 'Printer' },
+];
+
+export default function DeviceListScreen() {
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={mockDevices}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => <DeviceCard device={item} />}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+});

--- a/mobile/screens/HomeScreen.js
+++ b/mobile/screens/HomeScreen.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+
+export default function HomeScreen({ navigation }) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>IT Inventory Management</Text>
+      <Button
+        title="View Devices"
+        onPress={() => navigation.navigate('Devices')}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  title: {
+    fontSize: 18,
+    marginBottom: 12,
+  },
+});


### PR DESCRIPTION
## Summary
- add React Navigation stack with home and device list screens
- implement DeviceCard component and mock device list
- update lint script and dependencies

## Testing
- `npm run lint`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c00755f1b8832ea61d7bbe806be384